### PR TITLE
Hotfix: UC4 knoptekst correctie

### DIFF
--- a/Grocery.App/Views/ChangeColorView.xaml
+++ b/Grocery.App/Views/ChangeColorView.xaml
@@ -13,6 +13,6 @@
 
     <VerticalStackLayout>
         <Editor Text="{Binding GroceryList.Color}" x:Name="newColor"/>
-        <Button Text="wijzig kleur" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
+        <Button Text="Kleur bewaren" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
## Hotfix: UC4 Knoptekst Fix

### Probleem
TC4-01 test faalde omdat knoptekst "wijzig kleur" was in plaats van verwachte "Kleur bewaren".

### Oplossing
-  Knoptekst gewijzigd naar "Kleur bewaren" in ChangeColorView.xaml
-  Test TC4-01 slaagt nu

### Tests
- Manual test: UC4 werkt correct
- Pipeline tests: alle tests slagen